### PR TITLE
Fix the deployed url

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Uses Nasa's [Spot the Station](c) RSS Feed.
 
 ##
 
-Deployed to [spotthestation.ede.li](spotthestation.ede.li)
+Deployed to [spotthestation.ede.li](http://spotthestation.ede.li)
 
 ## Development
 


### PR DESCRIPTION
For some reason GitHub was treating it as a file, not an actual domain, and directing it to https://github.com/elitau/spotthestation/blob/master/spotthestation.ede.li instead of http://spotthestation.ede.li